### PR TITLE
Various fixes

### DIFF
--- a/media_tree/admin/actions/utils.py
+++ b/media_tree/admin/actions/utils.py
@@ -6,7 +6,6 @@ def get_actions_context(modeladmin):
     return {
         'node': FileNode.get_top_node(), # TODO get current folder
         "opts": modeladmin.model._meta,
-        "root_path": modeladmin.admin_site.root_path,
         "app_label": modeladmin.model._meta.app_label,
         'action_checkbox_name': helpers.ACTION_CHECKBOX_NAME,
     }

--- a/media_tree/contrib/legacy_mptt_support/admin.py
+++ b/media_tree/contrib/legacy_mptt_support/admin.py
@@ -158,7 +158,6 @@ class MPTTModelAdmin(ModelAdmin):
                 'cl': cl,
                 'media': media,
                 'has_add_permission': self.has_add_permission(request),
-                'root_path': self.admin_site.root_path,
                 'app_label': app_label,
                 'action_form': action_form,
                 'actions_on_top': self.actions_on_top,

--- a/media_tree/static/media_tree/js/admin_enhancements.js
+++ b/media_tree/static/media_tree/js/admin_enhancements.js
@@ -493,15 +493,4 @@ jQuery(function($) {
         return false;
     });
 
-    // Prebuffer background images
-    var bufferBackgroundElements = $('<div class="loading"><div class="folder-toggle" /></div>');
-    bufferBackgroundElements.hide();
-    $('body').append(bufferBackgroundElements);
-    $('*', bufferBackgroundElements).each(function() {
-        var matchUrl = $(this).css('background-image').match(/url\((.*)\)/);
-        var img = new Image();
-        img.src = matchUrl[1];
-    });
-    bufferBackgroundElements.remove();
-
 });

--- a/media_tree/templatetags/media_tree_thumbnail.py
+++ b/media_tree/templatetags/media_tree_thumbnail.py
@@ -185,6 +185,9 @@ class ThumbnailNode(Node):
         if self.context_name is None:
             return escape(thumbnail.url)
         else:
+            # Prepopulate ImageFile dimensions cache to skip reading of
+            # thumbnail image and prevent IOError in case of missing file
+            thumbnail._dimensions_cache = opts['size']
             context[self.context_name] = thumbnail
             return ''
 


### PR DESCRIPTION
I fixed a few bugs I came across while setting `django-media-tree` up on Django 1.4:

- The Javascript code for preloading background images in the admin file browser does not work with relative URLs that are written in `ui.css` (at least in Firefox 10) and results in requests to: `/admin/media_tree/filenode/%22http%3A//127.0.0.1%3A8000/static/media_tree/img/icons/folder-toggle.png%22/`

- In case of using a thumbnail generator/image resizer (at least for `easy_thumbnails`) the execution stops with an `IOError` exception if the file does not exist. The exception happens as a consequence of `{{ thumb.width }}` in `templates/media_tree/filenode/includes/figure_base.html` that wants to read the image file to determine its width (the results are stored in `ImageFile` dimension cache). This reading of files is unnecessary, because the dimensions of the thumbnail are already known to the template tag, and also to work around the common crash in case of missing files, I prepopulate the dimensions field.

- Django 1.4 also removed the deprecated `root_path` admin context variable that is not even used in `django-media-tree` and can therefore be removed.