### PR TITLE
Fix ImproperlyConfigured on forms of cms-plugins w/ Django>=1.8

### DIFF
--- a/media_tree/contrib/cms_plugins/media_tree_gallery/cms_plugins.py
+++ b/media_tree/contrib/cms_plugins/media_tree_gallery/cms_plugins.py
@@ -14,6 +14,7 @@ from django.http import Http404
 class MediaTreeGalleryPluginForm(MediaTreePluginFormInlinePositioningBase):
     class Meta:
         model = MediaTreeGallery
+        fields = '__all__'
 
 
 class MediaTreeGalleryItemInline(admin.StackedInline):

--- a/media_tree/contrib/cms_plugins/media_tree_image/cms_plugins.py
+++ b/media_tree/contrib/cms_plugins/media_tree_image/cms_plugins.py
@@ -14,6 +14,7 @@ from django.utils.translation import ugettext_lazy as _
 class MediaTreeImagePluginForm(MediaTreePluginFormBase):
     class Meta:
         model = MediaTreeImage
+        fields = '__all__'
 
 
 class MediaTreeImagePlugin(CMSPluginBase, ImageNodeDetailMixin):

--- a/media_tree/contrib/cms_plugins/media_tree_listing/cms_plugins.py
+++ b/media_tree/contrib/cms_plugins/media_tree_listing/cms_plugins.py
@@ -8,10 +8,10 @@ from django.contrib import admin
 
 
 class MediaTreeListingPluginForm(MediaTreePluginFormInlinePositioningBase):
-    
     class Meta:
         model = MediaTreeListing
-    
+        fields = '__all__'
+
 
 class MediaTreeListingItemInline(admin.StackedInline):
     model = MediaTreeListingItem

--- a/media_tree/contrib/cms_plugins/media_tree_slideshow/cms_plugins.py
+++ b/media_tree/contrib/cms_plugins/media_tree_slideshow/cms_plugins.py
@@ -13,6 +13,7 @@ from django.contrib import admin
 class MediaTreeSlideshowPluginForm(MediaTreePluginFormInlinePositioningBase):
     class Meta:
         model = MediaTreeSlideshow
+        fields = '__all__'
 
 
 class MediaTreeSlideshowItemInline(admin.StackedInline):


### PR DESCRIPTION
These changes make `django-media-tree` work with Django 1.8 and django CMS 3 (tested with `Django==1.8.3`, `django-cms==3.1.2`). This fixes issue #37 definitely for Django 1.8.

**Caution!** These changes should probably be tested with Django versions < 1.8. I've only lightly tested with Django 1.7.10, and didn't care setting up a whole new project with Django 1.6.11.