### PR TITLE
Add first integration tests, build demo_project using tox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
+/.cache/
 /.coverage
 /.tox/
+/build/
 /dist/
 /django-media-tree.egg/
 /django_media_tree.egg-info/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 install:
-  - pip install coveralls tox
+  - pip install tox
 script:
   - tox
 env:  # generate list with: $ tox -l | xargs -I ITEM echo "  - TOXENV="ITEM

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: python
-install:
-  - pip install tox
 script:
-  - tox
+  - python setup.py -q test
 env:  # generate list with: $ tox -l | xargs -I ITEM echo "  - TOXENV="ITEM
   - TOXENV=py26-django15
   - TOXENV=py26-django16
@@ -10,11 +8,13 @@ env:  # generate list with: $ tox -l | xargs -I ITEM echo "  - TOXENV="ITEM
   - TOXENV=py27-django16
   - TOXENV=py27-django17
   - TOXENV=py27-django18
+  - TOXENV=py32-django15
+  - TOXENV=py32-django16
+  - TOXENV=py32-django17
+  - TOXENV=py32-django18
   - TOXENV=py33-django15
   - TOXENV=py33-django16
   - TOXENV=py33-django17
   - TOXENV=py33-django18
-  - TOXENV=py34-django15
-  - TOXENV=py34-django16
   - TOXENV=py34-django17
   - TOXENV=py34-django18

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Django Media Tree |latest-version|
 **********************************
 
-|travis-ci| |coveralls| |downloads| |license|
+|travis-ci| |coveralls| |health| |downloads| |license|
 
 Django Media Tree is a Django app for managing your website's media files in a
 folder tree, and using them in your own applications.
@@ -44,3 +44,19 @@ Documentation
 =============
 
 http://django-media-tree.readthedocs.org/
+
+Development
+===========
+
+Contributors should make sure the demo project builds successfully with their
+changes before placing a pull request on GitHub.  This is best done by running
+the tests.
+
+* Either: ``python setup.py -q test`` (run ``tox`` against all supported versions)
+* Or: ``python setup.py test -a --skip-missing-interpreters`` (skip Python
+  interpreters that are not available)
+* Or: ``python setup.py test -a "-e py27-django16"`` (only test the Python 2.7
+  + Django 1.6 combination)
+
+It's also advisable to run ``flake8`` and address complaints before pushing
+changes to ensure code health increases.

--- a/demo_project/demo_project/settings.py
+++ b/demo_project/demo_project/settings.py
@@ -111,3 +111,7 @@ TEMPLATE_LOADERS = (
     'django.template.loaders.app_directories.Loader',
     # 'django.template.loaders.eggs.Loader',
 )
+
+FIXTURE_DIRS = (
+    os.path.join(BASE_DIR, 'fixtures'),
+)

--- a/demo_project/demo_project/settings.py
+++ b/demo_project/demo_project/settings.py
@@ -102,12 +102,12 @@ MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
 MEDIA_URL = '/media/'
 
 TEMPLATE_DIRS = (
-    os.path.join(BASE_DIR, 'templates')
+    os.path.join(BASE_DIR, 'templates'),
 )
 
 # List of callables that know how to import templates from various sources.
 TEMPLATE_LOADERS = (
     'django.template.loaders.filesystem.Loader',
     'django.template.loaders.app_directories.Loader',
-#     'django.template.loaders.eggs.Loader',
+    # 'django.template.loaders.eggs.Loader',
 )

--- a/demo_project/demo_project/urls.py
+++ b/demo_project/demo_project/urls.py
@@ -8,11 +8,9 @@ from django.conf.urls import patterns, include, url
 from django.contrib import admin
 admin.autodiscover()
 
-urlpatterns = patterns('',
-
-	(r'^$', TemplateView.as_view(
-		template_name="media_tree/base.html"
-	)),
+urlpatterns = patterns(
+    '',
+    (r'^$', TemplateView.as_view(template_name="media_tree/base.html")),
 
     url(r'^listing/$', FileNodeListingView.as_view(
         # notice that queryset can be any iterable, for instance a list:
@@ -34,4 +32,3 @@ urlpatterns = patterns('',
 from django.conf import settings
 from django.conf.urls.static import static
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
-

--- a/media_tree/__init__.py
+++ b/media_tree/__init__.py
@@ -1,4 +1,3 @@
 from django.utils.translation import ugettext_lazy as _
 _('Media_tree')
 _('Media_Tree')
-

--- a/media_tree/models.py
+++ b/media_tree/models.py
@@ -56,10 +56,10 @@ def Property(func):
 
 
 class FileNodeManager(models.Manager):
-    """ 
-    A special manager that enables you to pass a ``path`` argument to 
-    :func:`get`, :func:`filter`, and :func:`exclude`, allowing you to 
-    retrieve ``FileNode`` objects by their full node path, 
+    """
+    A special manager that enables you to pass a ``path`` argument to
+    :func:`get`, :func:`filter`, and :func:`exclude`, allowing you to
+    retrieve ``FileNode`` objects by their full node path,
     which consists of the names of its parents and itself,
     e.g. ``"path/to/folder/readme.txt"``.
     """
@@ -89,8 +89,8 @@ class FileNodeManager(models.Manager):
         """
         Works just like the default Manager's :func:`filter` method, but
         you can pass an additional keyword argument named ``path`` specifying
-        the full **path of the folder whose immediate child objects** you 
-        want to retrieve, e.g. ``"path/to/folder"``. 
+        the full **path of the folder whose immediate child objects** you
+        want to retrieve, e.g. ``"path/to/folder"``.
         """
         if 'path' in kwargs:
             kwargs = self.get_filter_args_with_path(False, **kwargs)
@@ -100,8 +100,8 @@ class FileNodeManager(models.Manager):
         """
         Works just like the default Manager's :func:`exclude` method, but
         you can pass an additional keyword argument named ``path`` specifying
-        the full **path of the folder whose immediate child objects** you 
-        want to exclude, e.g. ``"path/to/folder"``. 
+        the full **path of the folder whose immediate child objects** you
+        want to exclude, e.g. ``"path/to/folder"``.
         """
         if 'path' in kwargs:
             kwargs = self.get_filter_args_with_path(False, **kwargs)
@@ -112,7 +112,7 @@ class FileNodeManager(models.Manager):
         Works just like the default Manager's :func:`get` method, but
         you can pass an additional keyword argument named ``path`` specifying
         the full path of the object you want to retrieve, e.g.
-        ``"path/to/folder/readme.txt"``. 
+        ``"path/to/folder/readme.txt"``.
         """
         if 'path' in kwargs:
             kwargs = self.get_filter_args_with_path(True, **kwargs)
@@ -164,7 +164,7 @@ class MultipleChoiceCommaSeparatedIntegerField(models.Field):
             # Skip validation for non-editable fields.
             return
         if self._choices and value:
-            print value
+            print(value)
             l = value
             if type(value) != list:
                 l = [ value ]
@@ -204,17 +204,17 @@ class FileNode(ModelBase):
        methods that facilitate queries and data manipulation when working with
        trees.
 
-    You can access the actual media associated to a ``FileNode`` model instance 
+    You can access the actual media associated to a ``FileNode`` model instance
     using the following fields:
 
     .. role:: descname(literal)
-       :class: descname 
+       :class: descname
 
     :descname:`file`
         The actual media file
 
     :descname:`preview_file`
-        An optional image file that will be used for previews. This is useful 
+        An optional image file that will be used for previews. This is useful
         for visual media that PIL cannot read, such as video files.
 
     These fields are of the class ``FileField``. Please see :ref:`configuration`
@@ -235,36 +235,36 @@ class FileNode(ModelBase):
     """ MPTT tree manager """
 
     objects = FileNodeManager()
-    """ 
+    """
     An instance of the :class:`FileNodeManager` class, providing methods for retrieving ``FileNode`` objects by their full node path.
     """
 
     published_objects = FileNodeManager({'published': True})
-    """ 
+    """
     A special manager with the same features as :attr:`objects`, but only displaying currently
     published objects.
     """
 
     folders = FileNodeManager({'node_type': FOLDER})
-    """ 
+    """
     A special manager with the same features as :attr:`objects`, but only displaying folder nodes.
     """
 
     files = FileNodeManager({'node_type': FILE})
-    """ 
+    """
     A special manager with the same features as :attr:`objects`, but only displaying file nodes,
     no folder nodes.
     """
 
     # FileFields -- have no docstring since Sphinx cannot access these attributes
     file = models.FileField(_('file'), upload_to=app_settings.MEDIA_TREE_UPLOAD_SUBDIR, null=True, storage=STORAGE)
-    # The actual media file 
+    # The actual media file
     preview_file = models.ImageField(_('preview'), upload_to=app_settings.MEDIA_TREE_PREVIEW_SUBDIR, blank=True, null=True, help_text=_('Use this field to upload a preview image for video or similar media types.'), storage=STORAGE)
-    # An optional image file that will be used for previews. This is useful for video files. 
+    # An optional image file that will be used for previews. This is useful for video files.
 
     parent = models.ForeignKey('self', null=True, blank=True, related_name='children', verbose_name=_('folder'), limit_choices_to={'node_type': FOLDER})
     """ The parent (folder) object of the node. """
-    
+
     node_type = models.IntegerField(_('node type'), choices = ((FOLDER, 'Folder'), (FILE, 'File')), editable=False, blank=False, null=False)
     """ Type of the node (:attr:`FileNode.FILE` or :attr:`FileNode.FOLDER`) """
     media_type = models.IntegerField(_('media type'), choices = app_settings.MEDIA_TREE_CONTENT_TYPE_CHOICES, blank=True, null=True, editable=False)
@@ -499,7 +499,7 @@ class FileNode(ModelBase):
     def get_path(self):
         path = ''
         for name in [node.name for node in self.get_ancestors()]:
-            path = '%s%s/' % (path, name) 
+            path = '%s%s/' % (path, name)
         return '%s%s' % (path, self.name)
 
     def get_admin_url(self, query_params=None, use_path=False):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 100
+exclude = build,dist,docs,*/migrations,*.egg-info

--- a/setup.py
+++ b/setup.py
@@ -35,22 +35,28 @@ setup(
     version='0.8.1',
     url='http://github.com/samluescher/django-media-tree',
     license='BSD',
-    description="Django Media Tree is a Django app for managing your website's media files in a folder tree, and using them in your own applications.",
+    description="Django Media Tree is a Django app for managing your website's "
+                "media files in a folder tree, and using them in your own applications.",
     long_description=read('README.rst'),
 
     author=u'Samuel Luescher',
     author_email='sam at luescher dot org',
 
-    packages = find_packages(),
+    packages=find_packages(),
     include_package_data=True,
 
-    classifiers = [
+    classifiers=[
         'Development Status :: 4 - Beta',
         'Framework :: Django',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.2',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
         'Topic :: Internet :: WWW/HTTP',
     ],
 

--- a/setup.py
+++ b/setup.py
@@ -1,23 +1,46 @@
 # encoding=utf8
 import os
+import sys
 from setuptools import setup, find_packages
+from setuptools.command.test import test as TestCommand
+
 
 def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
-README = read('README.rst')
+
+class Tox(TestCommand):
+    user_options = [('tox-args=', 'a', "Arguments to pass to tox")]
+
+    def initialize_options(self):
+        TestCommand.initialize_options(self)
+        self.tox_args = None
+
+    def finalize_options(self):
+        TestCommand.finalize_options(self)
+        self.test_args = []
+        self.test_suite = True
+
+    def run_tests(self):
+        import tox
+        import shlex
+        args = self.tox_args
+        if args:
+            args = shlex.split(self.tox_args)
+        errno = tox.cmdline(args=args)
+        sys.exit(errno)
 
 setup(
-    name = "django-media-tree",
-    version = "0.8.1",
-    url = 'http://github.com/samluescher/django-media-tree',
-    license = 'BSD',
-    description = "Django Media Tree is a Django app for managing your website's media files in a folder tree, and using them in your own applications.",
-    long_description = README,
+    name='django-media-tree',
+    version='0.8.1',
+    url='http://github.com/samluescher/django-media-tree',
+    license='BSD',
+    description="Django Media Tree is a Django app for managing your website's media files in a folder tree, and using them in your own applications.",
+    long_description=read('README.rst'),
 
-    author = u'Samuel Luescher',
-    author_email = 'sam at luescher dot org',
-    
+    author=u'Samuel Luescher',
+    author_email='sam at luescher dot org',
+
     packages = find_packages(),
     include_package_data=True,
 
@@ -29,5 +52,8 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Topic :: Internet :: WWW/HTTP',
-    ]
+    ],
+
+    tests_require=['tox'],
+    cmdclass={'test': Tox},
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    py{26}-django{15,16},
-    py{27,33,34}-django{15,16,17,18},
+    py{26,27,32,33}-django{15,16},
+    py{27,32,33,34}-django{17,18},
 
 [testenv]
 changedir = demo_project
@@ -11,15 +11,16 @@ commands =
     # TODO: for Django>=1.7 execute instead: ===
     # python manage.py migrate --noinput
     # python manage.py check
+    python manage.py loaddata initial_data
 deps =
     # Pillow
     django-mptt
     easy-thumbnails
     # wsgiref
+    django15,django16: South
     django15: Django>=1.5,<1.6
     django16: Django>=1.6,<1.7
     django17: Django>=1.7,<1.8
     django18: Django>=1.8,<1.9
-    django15,django16: South
 passenv =
     TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH

--- a/tox.ini
+++ b/tox.ini
@@ -4,18 +4,22 @@ envlist =
     py{27,33,34}-django{15,16,17,18},
 
 [testenv]
+changedir = demo_project
 commands =
-    coverage run setup.py test
-    coveralls
-basepython =
-    py26: python2.6
-    py27: python2.7
-    py33: python3.3
-    py34: python3.4
+    python manage.py syncdb --noinput
+    python manage.py validate
+    # TODO: for Django>=1.7 execute instead: ===
+    # python manage.py migrate --noinput
+    # python manage.py check
 deps =
-    coveralls
+    # Pillow
+    django-mptt
+    easy-thumbnails
+    # wsgiref
     django15: Django>=1.5,<1.6
     django16: Django>=1.6,<1.7
     django17: Django>=1.7,<1.8
     django18: Django>=1.8,<1.9
-passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
+    django15,django16: South
+passenv =
+    TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH


### PR DESCRIPTION
This is a first attempt of adding integration tests across supported Python and Django versions.

The demo project included in this repo can be built against several combinations of Python and Django using tox by issuing the usual `python setup.py test` command. All test builds are executed on Travis-CI (once the account there is activated).

With these changes merged moving towards Python 3 (e.g. PR #41), as any other contributions and refactoring, will start to be much easier. Safer to do, after all.